### PR TITLE
make sqlite3.statements() return an iterator

### DIFF
--- a/src/sqlite-api.js
+++ b/src/sqlite-api.js
@@ -502,8 +502,7 @@ export function Factory(Module) {
   //   return SQLite.SQLITE_OK;
   // };
   sqlite3.exec = function(db, sql, callback) {
-    const stmts = sqlite3.statements(db, sql, { unscoped: true });
-    for (const stmt of stmts) {
+    for (const stmt of sqlite3.statements(db, sql)) {
       let columns;
       while (sqlite3.step(stmt) === SQLite.SQLITE_ROW) {
         if (callback) {
@@ -512,9 +511,6 @@ export function Factory(Module) {
           callback(row, columns);
         }
       }
-    }
-    for (const stmt of stmts) {
-      sqlite3.finalize(stmt);
     }
     return SQLite.SQLITE_OK;
   };
@@ -775,9 +771,9 @@ export function Factory(Module) {
 
       const stmts = [];
 
-      // return (async function*() {
+    return (function*() {
       const onFinally = [];
-      // try {
+      try {
         // Encode SQL string to UTF-8.
         const utf8 = textEncoder.encode(sql);
 
@@ -815,12 +811,12 @@ export function Factory(Module) {
           // Allow retry operations.
           const zTail = Module.getValue(pzTail, '*');
           const rc = prepare(
-            db,
-            zTail,
-            pzEnd - pzTail,
-            options.flags || 0,
-            pStmt,
-            pzTail);
+              db,
+              zTail,
+              pzEnd - pzTail,
+              options.flags || 0,
+              pStmt,
+              pzTail);
 
           if (rc !== SQLite.SQLITE_OK) {
             check('sqlite3_prepare_v3', rc, db);
@@ -829,17 +825,15 @@ export function Factory(Module) {
           stmt = Module.getValue(pStmt, '*');
           if (stmt) {
             mapStmtToDB.set(stmt, db);
-            // yield stmt;
-            stmts.push(stmt);
+            yield stmt;
           }
         } while (stmt);
-      // } finally {
-      //   while (onFinally.length) {
-      //     onFinally.pop()();
-      //   }
-      // }
-
-      return stmts;
+      } finally {
+        while (onFinally.length) {
+          onFinally.pop()();
+        }
+      }
+    })();
   };
 
   sqlite3.step = (function() {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -811,7 +811,7 @@ interface SQLiteAPI {
    * @param options
    */
   // statements(db: number, sql: string, options?: SQLitePrepareOptions): AsyncIterable<number>;
-  statements(db: number, sql: string, options?: SQLitePrepareOptions): ReadonlyArray<number>;
+  statements(db: number, sql: string, options?: SQLitePrepareOptions): Iterable<number>;
 
   /**
    * Evaluate an SQL statement


### PR DESCRIPTION
This is more similar to upstream wa-sqlite.

Trying to prepare multiple statements at the same time without applying them will cause things to break if any of the statements change the schema (e.g. adding a table that later statements rely on). Using an iterator again should fix this.

### Checklist
- [x] I grant to recipients of this Project distribution a perpetual,
non-exclusive, royalty-free, irrevocable copyright license to reproduce, prepare
derivative works of, publicly display, sublicense, and distribute this
Contribution and such derivative works.
- [x] I certify that I am legally entitled to grant this license, and that this
Contribution contains no content requiring a license from any third party.

TODO (probably next week):
- [ ] write tests somewhere (probably in livestore main repo, once I've got it set up in a devcontainer or something)
  - [ ] that we can create a table and immediately use it in the next statement in a single call to exec()
  - [ ] that if the second statement in an exec() fails to prepare/run, we can still dispose the database in the finally block (I think this is what's happening in https://github.com/alsuren/aoc-sqlite/commit/255ef720eab4927269fe8eb83f5eba1602a973e1 )